### PR TITLE
feat: add armor attributes system

### DIFF
--- a/src/content/armors.ts
+++ b/src/content/armors.ts
@@ -1,14 +1,68 @@
 import type { ArmorDef } from '../core/Types'
 
 const catalog: ArmorDef[] = [
-  { id: 'cloth-robe', name: '布衣', def: 1, desc: '尋常衣物，幾乎沒有防護力。' },
-  { id: 'leather-vest', name: '皮革護甲', def: 4, desc: '輕薄的襯層，可稍稍緩衝衝擊。' },
-  { id: 'windwalk-cloak', name: '風行斗篷', def: 5, desc: '以風絲織就的披覆，減緩來襲之勢。', minFloor: 2 },
-  { id: 'scale-mail', name: '鱗甲', def: 7, desc: '厚重的甲片，以速度換取安全。', minFloor: 3 },
-  { id: 'river-ward-mail', name: '川衛軟甲', def: 8, desc: '水紋皮革層層包覆，能順勢卸力。', minFloor: 3 },
-  { id: 'spirit-robe', name: '靈紋法袍', def: 6, desc: '符咒縈繞的衣料，增強真氣。', minFloor: 4 },
-  { id: 'phoenix-ward', name: '鳳羽護衣', def: 9, desc: '覆有赤羽的護衣，灼熱氣息守護身軀。', minFloor: 4 },
-  { id: 'starfall-plate', name: '墜星重鎧', def: 11, desc: '隕星鋪鑄的厚鎧，連山岳衝擊也難以撼動。', minFloor: 5 }
+  {
+    id: 'cloth-robe',
+    name: '布衣',
+    def: 0,
+    desc: '尋常衣物，幾乎沒有防護力。',
+    attributeIds: ['light-padding']
+  },
+  {
+    id: 'leather-vest',
+    name: '皮革護甲',
+    def: 1,
+    desc: '輕薄的襯層，可稍稍緩衝衝擊。',
+    attributeIds: ['light-padding', 'wind-channeling']
+  },
+  {
+    id: 'windwalk-cloak',
+    name: '風行斗篷',
+    def: 2,
+    desc: '以風絲織就的披覆，減緩來襲之勢。',
+    minFloor: 2,
+    attributeIds: ['wind-channeling', 'gust-barrier']
+  },
+  {
+    id: 'scale-mail',
+    name: '鱗甲',
+    def: 3,
+    desc: '厚重的甲片，以速度換取安全。',
+    minFloor: 3,
+    attributeIds: ['scale-reinforcement', 'light-padding']
+  },
+  {
+    id: 'river-ward-mail',
+    name: '川衛軟甲',
+    def: 3,
+    desc: '水紋皮革層層包覆，能順勢卸力。',
+    minFloor: 3,
+    attributeIds: ['riverflow-weave', 'wind-channeling']
+  },
+  {
+    id: 'spirit-robe',
+    name: '靈紋法袍',
+    def: 2,
+    desc: '符咒縈繞的衣料，增強真氣。',
+    minFloor: 4,
+    attributeIds: ['spirit-warding', 'light-padding']
+  },
+  {
+    id: 'phoenix-ward',
+    name: '鳳羽護衣',
+    def: 2,
+    desc: '覆有赤羽的護衣，灼熱氣息守護身軀。',
+    minFloor: 4,
+    attributeIds: ['phoenix-ember', 'wind-channeling', 'light-padding']
+  },
+  {
+    id: 'starfall-plate',
+    name: '墜星重鎧',
+    def: 3,
+    desc: '隕星鋪鑄的厚鎧，連山岳衝擊也難以撼動。',
+    minFloor: 5,
+    attributeIds: ['starfall-bastion', 'scale-reinforcement']
+  }
 ]
 
 export const armors: ArmorDef[] = catalog

--- a/src/core/Types.ts
+++ b/src/core/Types.ts
@@ -26,6 +26,17 @@ export interface EnemyDef {
 export type WeaponAttributeId = 'armor-break' | 'fury-strike' | 'vampiric-edge' | 'storm-surge'
 export type WeaponAttributeChargeMap = Partial<Record<WeaponAttributeId, number>>
 
+export type ArmorAttributeId =
+  | 'light-padding'
+  | 'wind-channeling'
+  | 'gust-barrier'
+  | 'scale-reinforcement'
+  | 'riverflow-weave'
+  | 'spirit-warding'
+  | 'phoenix-ember'
+  | 'starfall-bastion'
+
+export type ArmorAttributeBonuses = { def: number }
 
 export interface WeaponAttributeDef {
   id: WeaponAttributeId
@@ -38,7 +49,21 @@ export interface WeaponAttributeDef {
 }
 
 export interface WeaponDef { id: string; name: string; atk: number; desc?: string; minFloor?: number; attributeIds?: WeaponAttributeId[] }
-export interface ArmorDef { id: string; name: string; def: number; desc?: string; minFloor?: number }
+export interface ArmorAttributeDef {
+  id: ArmorAttributeId
+  name: string
+  description: string
+  defBonus?: number
+}
+
+export interface ArmorDef {
+  id: string
+  name: string
+  def: number
+  desc?: string
+  minFloor?: number
+  attributeIds?: ArmorAttributeId[]
+}
 export interface PlayerStats { hp: number; mp: number }
 export interface ItemGrant { id: string; quantity?: number }
 export interface StatusDef {

--- a/src/game/armors/armorAttributes.ts
+++ b/src/game/armors/armorAttributes.ts
@@ -1,0 +1,86 @@
+import type {
+  ArmorAttributeBonuses,
+  ArmorAttributeDef,
+  ArmorAttributeId
+} from '../../core/Types'
+
+const definitions: ArmorAttributeDef[] = [
+  {
+    id: 'light-padding',
+    name: '輕軟護層',
+    description: '貼身的內襯吸收衝擊，額外提供 1 點防禦。',
+    defBonus: 1
+  },
+  {
+    id: 'wind-channeling',
+    name: '導風紋絡',
+    description: '導引來風卸力，額外提供 2 點防禦。',
+    defBonus: 2
+  },
+  {
+    id: 'gust-barrier',
+    name: '風障護幕',
+    description: '旋風守護身周，再獲 1 點防禦。',
+    defBonus: 1
+  },
+  {
+    id: 'scale-reinforcement',
+    name: '鱗片加固',
+    description: '堅實鱗片錯落堆疊，額外提供 3 點防禦。',
+    defBonus: 3
+  },
+  {
+    id: 'riverflow-weave',
+    name: '川流織護',
+    description: '如水勢般導流衝擊，再添 3 點防禦。',
+    defBonus: 3
+  },
+  {
+    id: 'spirit-warding',
+    name: '靈紋護結',
+    description: '靈光成結界，額外提供 3 點防禦。',
+    defBonus: 3
+  },
+  {
+    id: 'phoenix-ember',
+    name: '鳳炎守耀',
+    description: '炙炎羽翼環身，再增 4 點防禦。',
+    defBonus: 4
+  },
+  {
+    id: 'starfall-bastion',
+    name: '墜星壁垣',
+    description: '星鋼壁障凝實，額外提供 5 點防禦。',
+    defBonus: 5
+  }
+]
+
+export const armorAttributes = definitions
+
+export const armorAttributesById = new Map<ArmorAttributeId, ArmorAttributeDef>(
+  definitions.map(def => [def.id, def])
+)
+
+export function getArmorAttributes(ids: ArmorAttributeId[] = []): ArmorAttributeDef[] {
+  const results: ArmorAttributeDef[] = []
+  for (const id of ids) {
+    const def = armorAttributesById.get(id)
+    if (def) results.push(def)
+  }
+  return results
+}
+
+export function sumArmorAttributeBonuses(attributes: ArmorAttributeDef[]): ArmorAttributeBonuses {
+  return attributes.reduce<ArmorAttributeBonuses>(
+    (acc, attribute) => {
+      acc.def += attribute.defBonus ?? 0
+      return acc
+    },
+    { def: 0 }
+  )
+}
+
+export function getArmorAttributeBonuses(ids: ArmorAttributeId[] | undefined): ArmorAttributeBonuses {
+  const attributes = getArmorAttributes(ids ?? [])
+  return sumArmorAttributeBonuses(attributes)
+}

--- a/src/game/player/PlayerState.ts
+++ b/src/game/player/PlayerState.ts
@@ -15,6 +15,7 @@ import { getSkillDef, skills } from '../../content/skills'
 import { getWeaponDef } from '../../content/weapons'
 import { getArmorDef } from '../../content/armors'
 import { getWeaponAttributes, normalizeWeaponAttributeCharge, normalizeWeaponAttributeCharges } from '../weapons/weaponAttributes'
+import { getArmorAttributes, sumArmorAttributeBonuses } from '../armors/armorAttributes'
 
 export type InventoryEntry = { def: ItemDef; quantity: number }
 export type ActiveStatus = { def: StatusDef; remaining: number }
@@ -159,6 +160,11 @@ export class PlayerState {
       },
       { atk: 0, def: 0 }
     )
+  }
+
+  getArmorAttributeBonuses() {
+    const attributes = getArmorAttributes(this.armor?.attributeIds ?? [])
+    return sumArmorAttributeBonuses(attributes)
   }
 
   serialize(): SerializedPlayerState {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -230,6 +230,10 @@ export class GameScene extends Phaser.Scene {
     return this.playerState.getStatusBonuses()
   }
 
+  getArmorAttributeBonuses() {
+    return this.playerState.getArmorAttributeBonuses()
+  }
+
   init(data?: { floor?: number; reset?: boolean; entry?: 'up' | 'down'; startMode?: 'load' }) {
     if (data?.reset) this.resetPlayerState()
     this.floor = data?.floor ?? this.floor ?? 1

--- a/src/scenes/LibraryOverlay.ts
+++ b/src/scenes/LibraryOverlay.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser'
 import type { ArmorDef, SkillDef, WeaponDef } from '../core/Types'
 import type { GameScene } from './GameScene'
 import type { InventoryEntry } from '../game/player/PlayerState'
+import { getArmorAttributes, sumArmorAttributeBonuses } from '../game/armors/armorAttributes'
 
 export type LibraryCategory = 'weapons' | 'armor' | 'items' | 'skills'
 
@@ -287,17 +288,31 @@ export class LibraryOverlay {
       ? stash.map((armor, idx) => {
           const pointer = idx === this.selectedIndex ? '>' : ' '
           const equipped = armor.id === currentId ? '[E]' : '   '
-          return `${pointer} ${equipped} ${idx + 1}. ${armor.name}（防禦 ${armor.def}）`
+          const attributes = getArmorAttributes(armor.attributeIds ?? [])
+          const attributeBonuses = sumArmorAttributeBonuses(attributes)
+          const totalDef = armor.def + attributeBonuses.def
+          const bonusText = attributeBonuses.def ? `（屬性 +${attributeBonuses.def}）` : ''
+          return `${pointer} ${equipped} ${idx + 1}. ${armor.name}（防禦 ${totalDef}${bonusText}）`
         })
       : ['（空）']
 
     let detail = '未選擇任何防具。'
     const armor = stash[this.selectedIndex]
     if (armor) {
+      const attributes = getArmorAttributes(armor.attributeIds ?? [])
+      const attributeBonuses = sumArmorAttributeBonuses(attributes)
+      const totalDef = armor.def + attributeBonuses.def
+      const bonusText = attributeBonuses.def ? `（屬性 +${attributeBonuses.def}）` : ''
       const detailLines = [
         `${armor.name}`,
-        `防禦 ${armor.def}`
+        `防禦 ${totalDef}${bonusText}`
       ]
+      if (attributes.length) {
+        for (const attribute of attributes) {
+          detailLines.push(`屬性 ${attribute.name}`)
+          detailLines.push(attribute.description)
+        }
+      }
       if (armor.desc) detailLines.push(armor.desc)
       detail = detailLines.join('\n')
     }

--- a/src/systems/combat.ts
+++ b/src/systems/combat.ts
@@ -18,8 +18,11 @@ export type CombatOutcome = {
 
 export function getEffectiveCombatStats(scene: any) {
   const bonuses = typeof scene.getStatusBonuses === 'function' ? scene.getStatusBonuses() : { atk: 0, def: 0 }
+  const armorAttributeBonuses =
+    typeof scene.getArmorAttributeBonuses === 'function' ? scene.getArmorAttributeBonuses() : { def: 0 }
   const weaponAtk = (scene.playerWeapon?.atk ?? 0) + (bonuses.atk ?? 0)
-  const armorDef = (scene.playerArmor?.def ?? 0) + (bonuses.def ?? 0)
+  const armorDef =
+    (scene.playerArmor?.def ?? 0) + (bonuses.def ?? 0) + (armorAttributeBonuses.def ?? 0)
   return { atk: weaponAtk, def: armorDef }
 }
 

--- a/src/systems/render.ts
+++ b/src/systems/render.ts
@@ -5,6 +5,7 @@ import type { SkillDef } from '../core/Types'
 import { getEffectiveCombatStats } from './combat'
 
 import { getWeaponAttributes, getWeaponAttributeChargeMax, isWeaponAttributeReady, normalizeWeaponAttributeCharges } from '../game/weapons/weaponAttributes'
+import { getArmorAttributes, sumArmorAttributeBonuses } from '../game/armors/armorAttributes'
 
 const SKILL_HOTKEYS = ['Q', 'W', 'E', 'R', 'T', 'Y', 'U']
 
@@ -189,7 +190,11 @@ function describeTile(scene: any, tile: string, x: number, y: number): string | 
     case 'armor': {
       const armor = scene.armorDrops?.get(posKey)
       if (!armor) return '防具：未知'
-      return `防具：${armor.name}（防禦 ${armor.def}）`
+      const attributes = getArmorAttributes(armor.attributeIds ?? [])
+      const bonuses = sumArmorAttributeBonuses(attributes)
+      const totalDef = armor.def + bonuses.def
+      const bonusText = bonuses.def ? `（屬性 +${bonuses.def}）` : ''
+      return `防具：${armor.name}（防禦 ${totalDef}${bonusText}）`
     }
     case 'item': {
       const item = scene.itemDrops?.get(posKey)
@@ -346,7 +351,17 @@ export function draw(scene: any) {
 
   if (scene.playerArmor) {
     const armor = scene.playerArmor
-    statsLines.push(`  +防禦 ${armor.def}`)
+    const attributes = getArmorAttributes(armor.attributeIds ?? [])
+    const attributeBonuses = sumArmorAttributeBonuses(attributes)
+    const totalDef = armor.def + attributeBonuses.def
+    const bonusText = attributeBonuses.def ? `（屬性 +${attributeBonuses.def}）` : ''
+    statsLines.push(`  +防禦 ${totalDef}${bonusText}`)
+    if (attributes.length) {
+      for (const attribute of attributes) {
+        statsLines.push(`  屬性 ${attribute.name}`)
+        statsLines.push(`  ${attribute.description}`)
+      }
+    }
     if (armor.desc) statsLines.push(`  ${armor.desc}`)
   }
 


### PR DESCRIPTION
## Summary
- introduce reusable armor attribute definitions and expose IDs on armor catalog entries
- include armor attribute bonuses when computing defense values during combat and state management
- update battle, library, and HUD rendering to display armor attribute details alongside total defense

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d480316c40832eba50fd4fd794c53b