### PR TITLE
Remove hotkeys for skills and items on main screen

### DIFF
--- a/src/systems/input.ts
+++ b/src/systems/input.ts
@@ -28,14 +28,6 @@ export function handleInput(scene: any, key: string) {
     }
     return
   }
-  const skillMap: Record<string, number> = { q: 0, w: 1, e: 2, r: 3, t: 4, y: 5, u: 6 }
-  const skillIndex = skillMap[key.toLowerCase()]
-  if (typeof skillIndex === "number") {
-    if (scene.useSkill?.(skillIndex)) return
-  }
-  if (/^[1-9]$/.test(key)) {
-    if (scene.useInventorySlot?.(Number.parseInt(key, 10) - 1)) return
-  }
   const dir = ({
     ArrowUp: { x: 0, y: -1 }, ArrowDown: { x: 0, y: 1 }, ArrowLeft: { x: -1, y: 0 }, ArrowRight: { x: 1, y: 0 },
     w: { x: 0, y: -1 }, s: { x: 0, y: 1 }, a: { x: -1, y: 0 }, d: { x: 1, y: 0 }

--- a/src/systems/render.ts
+++ b/src/systems/render.ts
@@ -7,7 +7,6 @@ import { getEffectiveCombatStats } from './combat'
 import { getWeaponAttributes, getWeaponAttributeChargeMax, isWeaponAttributeReady, normalizeWeaponAttributeCharges } from '../game/weapons/weaponAttributes'
 import { getArmorAttributes, sumArmorAttributeBonuses } from '../game/armors/armorAttributes'
 
-const SKILL_HOTKEYS = ['Q', 'W', 'E', 'R', 'T', 'Y', 'U']
 
 const TILE_TEXTURE_KEY = 'floor_wall'
 const SYMBOL_TEXTURE_KEY = 'symbol_tiles'
@@ -405,7 +404,7 @@ export function draw(scene: any) {
 
   const knownSkills: SkillDef[] = scene.knownSkills ?? []
   const skillLines = knownSkills.map((skill, idx) => {
-    const hotkey = SKILL_HOTKEYS[idx] ?? `#${idx + 1}`
+    const label = `${idx + 1}. ${skill.name}`
     let cooldown = 0
     if (typeof scene.getSkillCooldown === 'function') {
       cooldown = scene.getSkillCooldown(skill.id) ?? 0
@@ -413,7 +412,7 @@ export function draw(scene: any) {
       cooldown = scene.skillCooldowns.get(skill.id) ?? 0
     }
     const state = cooldown > 0 ? `CD ${cooldown}` : '就緒'
-    return `${hotkey} ${skill.name} (${state})`
+    return `${label} (${state})`
   })
   const skillHeader = '技能：'
   const skillText = skillLines.length ? [skillHeader, ...skillLines].join('\n') : `${skillHeader} 無`
@@ -433,7 +432,7 @@ export function draw(scene: any) {
         return `${idx + 1}. ${label}${qty}`
       })
     : ['（空）']
-  const inventoryHeader = '背包（按 1-9 使用）'
+  const inventoryHeader = '背包'
   const inventoryText = [inventoryHeader, ...inventoryLines].join('\n')
   const inventoryColor = inventoryStacks.length ? '#cfe' : '#888888'
   addText(scene, activeTextIds, 'inventory', statsStartX, currentY, inventoryText, {
@@ -473,7 +472,6 @@ export function draw(scene: any) {
 
   const instructions = [
     '移動: WASD / 方向鍵',
-    '使用技能: Q/W/E',
     '開啟圖鑑: L',
     '存檔:P 讀檔:O'
   ].join('\n')


### PR DESCRIPTION
## Summary
- disable direct skill and item activation from the main scene input handler
- update HUD text to remove hotkey references for skills and inventory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d497feb5cc832e82bb916eb68b1767