### PR TITLE
feat: add lifespan system

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -136,7 +136,13 @@ export class GameScene extends Phaser.Scene {
     '“若見此字，別怕黑。” ',
     '然後你把符紙輕輕一按，世界再次刷新。'
   ]
+  private readonly lifespanEndingLines = [
+    '當你再度停下腳步，才察覺丹田真火已成餘燼。',
+    '漫長攀行換得滿身塵土，卻換不回流逝的歲月。',
+    '壽命已盡，求仙之路在此畫下句點。'
+  ]
   private endingTriggered = false
+  private lifespanEndingTriggered = false
   private readonly floorStates = new Map<number, FloorState>()
   private pendingEntry: 'up' | 'down' | null = null
   private pendingStartMode: 'load' | null = null
@@ -218,6 +224,22 @@ export class GameScene extends Phaser.Scene {
     return this.playerState.skillCooldowns
   }
 
+  get ageDisplay(): string {
+    return this.playerState.getAgeDisplay()
+  }
+
+  get lifespanLimitDisplay(): string {
+    return this.playerState.getAgeLimitDisplay()
+  }
+
+  get lifespanRemainingDisplay(): string {
+    return this.playerState.getRemainingAgeDisplay()
+  }
+
+  get isLifespanEndingActive(): boolean {
+    return this.lifespanEndingTriggered
+  }
+
   private appendActionMessages(lines: string[]) {
     const additions = lines.map(line => line.trim()).filter(line => line.length > 0)
     if (!additions.length) return
@@ -240,6 +262,7 @@ export class GameScene extends Phaser.Scene {
     this.pendingEntry = data?.entry ?? null
     this.pendingStartMode = data?.startMode === 'load' ? 'load' : null
     this.endingTriggered = false
+    this.lifespanEndingTriggered = false
   }
 
   resetPlayerState() {
@@ -255,6 +278,7 @@ export class GameScene extends Phaser.Scene {
     this.pendingEntry = null
     this.pendingStartMode = null
     this.endingTriggered = false
+    this.lifespanEndingTriggered = false
     this.syncFloorLastAction()
   }
 
@@ -294,6 +318,10 @@ export class GameScene extends Phaser.Scene {
     this.pendingStartMode = null
     if (shouldAutoLoad) {
       this.loadGame({ silent: true })
+    }
+
+    if (this.playerState.hasReachedAgeLimit()) {
+      this.triggerLifespanEnding()
     }
   }
 
@@ -865,6 +893,9 @@ export class GameScene extends Phaser.Scene {
         this.syncFloorLastAction()
       }
       draw(this)
+      if (this.playerState.hasReachedAgeLimit()) {
+        this.triggerLifespanEnding()
+      }
       return true
     } catch (error) {
       console.error('[AscendTower] 讀檔失敗', error)
@@ -990,6 +1021,10 @@ export class GameScene extends Phaser.Scene {
     const { npc, pos } = payload
     if (npc.id === 'ending') {
       this.handleEndingCompletion()
+      return
+    }
+    if (npc.id === 'lifespan-ending') {
+      this.handleLifespanEndingCompletion()
       return
     }
 
@@ -1277,7 +1312,7 @@ ${details}`, coins: this.coins }
     draw(this)
   }
 
-  advanceTurn(_reason: 'move' | 'item' | 'shop' | 'skill' = 'move'): boolean {
+  advanceTurn(reason: 'move' | 'item' | 'shop' | 'skill' = 'move'): boolean {
     const statusTick = this.playerState.tickStatuses()
     const skillTick = this.playerState.tickSkillCooldowns()
     const messages = [...statusTick.messages, ...skillTick]
@@ -1285,6 +1320,13 @@ ${details}`, coins: this.coins }
     if (statusTick.defeated) {
       this.handlePlayerDefeat()
       return false
+    }
+    if (reason === 'move') {
+      const reachedLimit = this.playerState.advanceAgeHalfMonth()
+      if (reachedLimit) {
+        this.triggerLifespanEnding()
+        return false
+      }
     }
     return true
   }
@@ -1304,6 +1346,33 @@ ${details}`, coins: this.coins }
     this.resetPlayerState()
     this.time.delayedCall(200, () => {
       this.scene.restart({ floor: 1, reset: true })
+    })
+  }
+
+  private triggerLifespanEnding() {
+    if (this.lifespanEndingTriggered) return
+    this.lifespanEndingTriggered = true
+    this.closeAllOverlays()
+    const lines = [
+      `年齡已達 ${this.lifespanLimitDisplay}，壽元枯竭。`,
+      '求仙之路終止於此。'
+    ]
+    this.appendActionMessages(lines)
+    this.syncFloorLastAction()
+    draw(this)
+
+    const finaleNpc: NpcDef = {
+      id: 'lifespan-ending',
+      name: '殘燈僧',
+      lines: [...this.lifespanEndingLines]
+    }
+
+    this.dialogueOverlay.open({ npc: finaleNpc, pos: this.grid.playerPos })
+  }
+
+  private handleLifespanEndingCompletion() {
+    this.time.delayedCall(320, () => {
+      this.scene.start('TitleScene')
     })
   }
 }

--- a/src/systems/input.ts
+++ b/src/systems/input.ts
@@ -16,6 +16,7 @@ export function handleInput(scene: any, key: string) {
   if (scene.eventOverlay?.isActive) return
   if (scene.shopOverlay?.isActive) return
   if (scene.libraryOverlay?.isActive) return
+  if (scene.isLifespanEndingActive) return
   if (key === "l" || key === "L") {
     if (typeof scene.toggleLibrary === "function") {
       scene.toggleLibrary()

--- a/src/systems/render.ts
+++ b/src/systems/render.ts
@@ -327,8 +327,17 @@ export function draw(scene: any) {
   const combatStats = getEffectiveCombatStats(scene)
   const totalItems = scene.inventory?.reduce((sum: number, stack: any) => sum + (stack.quantity ?? 0), 0) ?? 0
 
-  const statsLines = [
-    `樓層 ${scene.floor}`,
+  const statsLines = [`樓層 ${scene.floor}`]
+  if (typeof scene.ageDisplay === 'string' && scene.ageDisplay.length) {
+    statsLines.push(`年齡 ${scene.ageDisplay}`)
+  }
+  if (typeof scene.lifespanLimitDisplay === 'string' && scene.lifespanLimitDisplay.length) {
+    statsLines.push(`壽命上限 ${scene.lifespanLimitDisplay}`)
+  }
+  if (typeof scene.lifespanRemainingDisplay === 'string' && scene.lifespanRemainingDisplay.length) {
+    statsLines.push(`剩餘壽命 ${scene.lifespanRemainingDisplay}`)
+  }
+  statsLines.push(
     `生命 ${scene.playerStats?.hp ?? 0}`,
     `攻擊 ${combatStats.atk}`,
     `防禦 ${combatStats.def}`,
@@ -337,7 +346,7 @@ export function draw(scene: any) {
     `武器 ${scene.playerWeapon ? scene.playerWeapon.name : '無'}`,
     `防具 ${scene.playerArmor ? scene.playerArmor.name : '無'}`,
     `道具 ${totalItems}`
-  ]
+  )
 
   if (scene.playerWeapon) {
     const weapon = scene.playerWeapon


### PR DESCRIPTION
## Summary
- add lifespan tracking to the player state, including serialization and display helpers for lifespan progress
- integrate turn-based aging into GameScene and trigger a dedicated dialogue ending when the lifespan cap is reached
- surface lifespan data in the HUD and lock further input once the lifespan ending begins

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b61c5574832e88193d4765e92644