### PR TITLE
Open branch instances from doors

### DIFF
--- a/src/core/Grid.ts
+++ b/src/core/Grid.ts
@@ -38,6 +38,7 @@ export class Grid {
       t === 'key' ||
       t === 'stairs_up' ||
       t === 'stairs_down' ||
+      t === 'stairs_branch' ||
       t === 'enemy' ||
       t === 'player' ||
       t === 'door' ||
@@ -153,6 +154,24 @@ export class Grid {
   }
 
   private carvePath(a: Vec2, b: Vec2) {
+    const dx = Math.sign(b.x - a.x)
+    const dy = Math.sign(b.y - a.y)
+
+    let x = a.x
+    let y = a.y
+
+    while (x !== b.x) {
+      x += dx
+      if (this.tiles[y][x] === 'wall') this.tiles[y][x] = 'floor'
+    }
+
+    while (y !== b.y) {
+      y += dy
+      if (this.tiles[y][x] === 'wall') this.tiles[y][x] = 'floor'
+    }
+  }
+
+  connectTiles(a: Vec2, b: Vec2) {
     const dx = Math.sign(b.x - a.x)
     const dy = Math.sign(b.y - a.y)
 

--- a/src/core/Types.ts
+++ b/src/core/Types.ts
@@ -6,6 +6,7 @@ export type Tile =
   | 'door'
   | 'stairs_up'
   | 'stairs_down'
+  | 'stairs_branch'
   | 'enemy'
   | 'player'
   | 'weapon'

--- a/src/systems/input.ts
+++ b/src/systems/input.ts
@@ -58,9 +58,15 @@ export function handleInput(scene: any, key: string) {
       scene.hasKey = true
       scene.grid.setTileUnderPlayer('floor')
       break
-    case 'door':
+    case 'door': {
+      const openedBranch = typeof scene.tryEnterDoorBranch === 'function' ? scene.tryEnterDoorBranch() : false
+      if (openedBranch) {
+        scene.transitionFloor?.('branch')
+        return
+      }
       scene.grid.setTileUnderPlayer('floor')
       break
+    }
     case 'weapon':
       pickupWeapon(scene, nextPos)
       scene.grid.setTileUnderPlayer('floor')
@@ -89,10 +95,13 @@ export function handleInput(scene: any, key: string) {
       }
       return
     case 'stairs_up':
-      scene.transitionFloor?.('up')
+      scene.transitionFloor?.(scene.isBranchFloor ? 'return' : 'up')
       return
     case 'stairs_down':
-      scene.transitionFloor?.('down')
+      scene.transitionFloor?.(scene.isBranchFloor ? 'return' : 'down')
+      return
+    case 'stairs_branch':
+      scene.transitionFloor?.('branch')
       return
     default:
       break

--- a/src/systems/render.ts
+++ b/src/systems/render.ts
@@ -26,6 +26,7 @@ const SYMBOL_BY_TILE: Record<string, SymbolConfig> = {
   door: { frame: 2 },
   stairs_up: { frame: 3 },
   stairs_down: { frame: 3, flipY: true },
+  stairs_branch: { frame: 3, tint: 0x8fdcff },
   enemy: { frame: 4 },
   weapon: { frame: 5 },
   armor: { frame: 6 },
@@ -228,6 +229,8 @@ function describeTile(scene: any, tile: string, x: number, y: number): string | 
       return '樓梯：向上'
     case 'stairs_down':
       return '樓梯：向下'
+    case 'stairs_branch':
+      return '樓梯：支線'
     default:
       return null
   }
@@ -327,7 +330,8 @@ export function draw(scene: any) {
   const combatStats = getEffectiveCombatStats(scene)
   const totalItems = scene.inventory?.reduce((sum: number, stack: any) => sum + (stack.quantity ?? 0), 0) ?? 0
 
-  const statsLines = [`樓層 ${scene.floor}`]
+  const floorLabel = typeof scene.floorDisplayName === 'string' ? scene.floorDisplayName : `樓層 ${scene.floor}`
+  const statsLines = [floorLabel]
   if (typeof scene.ageDisplay === 'string' && scene.ageDisplay.length) {
     statsLines.push(`年齡 ${scene.ageDisplay}`)
   }


### PR DESCRIPTION
## Summary
- allow door tiles to register as branch entrances and trigger branch transitions using the new branch system
- update keyboard input handling so unlocking a door immediately opens the associated branch dungeon instead of just clearing the tile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4c719099c832eac07872c2b487500