### PR TITLE
Add mission system with tracking and UI

### DIFF
--- a/src/content/missions.ts
+++ b/src/content/missions.ts
@@ -1,0 +1,72 @@
+import type { MissionDef } from '../core/Types'
+
+export const missions: MissionDef[] = [
+  {
+    id: 'reach-floor-3',
+    title: '踏入第三層',
+    description: '抵達第三層，確認自己能在塔內立足。',
+    goal: { type: 'reach-floor', target: 3 },
+    reward: {
+      message: '你熟悉了塔的節奏，獲得額外的旅費。',
+      coinDelta: 60
+    }
+  },
+  {
+    id: 'defeat-10-enemies',
+    title: '試煉戰士',
+    description: '擊敗十名敵人，磨練戰鬥本能。',
+    goal: { type: 'defeat-enemies', target: 10 },
+    reward: {
+      message: '戰鬥經驗化作資源，你整理包裹獲得補給。',
+      grantItems: [{ id: 'healing-herb', quantity: 3 }]
+    }
+  },
+  {
+    id: 'collect-5-items',
+    title: '行囊漸滿',
+    description: '收集五件道具，為長途冒險做好準備。',
+    goal: { type: 'collect-items', target: 5 },
+    reward: {
+      message: '井然有序的行囊令你心安，獲得蓄能水晶。',
+      grantItems: [{ id: 'charge-crystal', quantity: 1 }]
+    }
+  },
+  {
+    id: 'collect-200-coins',
+    title: '積攢資源',
+    description: '累積獲得兩百枚金幣，保障旅途所需。',
+    goal: { type: 'collect-coins', target: 200 },
+    reward: {
+      message: '你妥善規劃開銷，額外獲得一袋金幣。',
+      coinDelta: 120
+    }
+  },
+  {
+    id: 'gather-healing-herbs',
+    title: '療草傳遞',
+    description: '替塔樓老者收集兩株療傷藥草，證明你能照護同伴。',
+    goal: { type: 'collect-items', target: 2, itemId: 'healing-herb' },
+    reward: {
+      message: '老者熬成清香藥湯，你的傷勢逐漸復原。',
+      hpDelta: 30
+    },
+    autoUnlock: false
+  },
+  {
+    id: 'curator-salvage',
+    title: '遺物採錄',
+    description: '協助武庫典藏師擊敗五名敵人，為他蒐集戰場見聞。',
+    goal: { type: 'defeat-enemies', target: 5 },
+    reward: {
+      message: '典藏師將整理好的補給交到你手中。',
+      grantItems: [{ id: 'iron-ration', quantity: 2 }]
+    },
+    autoUnlock: false
+  }
+]
+
+const missionMap = new Map(missions.map(mission => [mission.id, mission]))
+
+export function getMissionDef(id: string): MissionDef | undefined {
+  return missionMap.get(id)
+}

--- a/src/content/npcs.ts
+++ b/src/content/npcs.ts
@@ -6,13 +6,14 @@ export const npcs: NpcDef[] = [
     name: '塔樓老者',
     lines: [
       '天梯會記住你踏出的每一步。',
-      '調勻呼吸，盯緊目標，一層層攀上去。'
+      '若能帶回兩株療傷藥草，證明你已懂得照護同伴。'
     ],
-    postMessage: '老者傳授了一個簡易吐納法。',
+    postMessage: '老者遞來竹籃，要你沿途留心療草。',
     outcome: {
       message: "聽了指點後，你覺得心神安穩。",
       hpDelta: 8
-    }
+    },
+    offeredMissionIds: ['gather-healing-herbs']
   },
   {
     id: 'scout',
@@ -30,12 +31,14 @@ export const npcs: NpcDef[] = [
     minFloor: 3,
     lines: [
       '我替每位陣亡挑戰者記錄遺物。',
-      '把這些帶上路，讓故事延續。'
+      '把這些帶上路，讓故事延續。',
+      '若你擊敗五名敵人，記得回來告訴我。'
     ],
     outcome: {
       message: '典藏師默默遞給你保存良好的補給品。',
       grantItems: [{ id: 'iron-ration', quantity: 1 }]
-    }
+    },
+    offeredMissionIds: ['curator-salvage']
   },
   {
     id: 'battle-scholar',

--- a/src/core/Types.ts
+++ b/src/core/Types.ts
@@ -155,4 +155,27 @@ export interface NpcDef {
   postMessage?: string
   outcome?: EventOutcome
   minFloor?: number
+  offeredMissionIds?: string[]
+}
+
+export type MissionGoal =
+  | { type: 'reach-floor'; target: number }
+  | { type: 'defeat-enemies'; target: number }
+  | { type: 'collect-coins'; target: number }
+  | { type: 'collect-items'; target: number; itemId?: string }
+
+export interface MissionDef {
+  id: string
+  title: string
+  description: string
+  goal: MissionGoal
+  reward?: EventOutcome
+  autoUnlock?: boolean
+}
+
+export interface MissionStatus {
+  def: MissionDef
+  progress: number
+  target: number
+  completed: boolean
 }

--- a/src/systems/spawning.ts
+++ b/src/systems/spawning.ts
@@ -78,10 +78,9 @@ export function pickupItem(scene: any, pos: Vec2) {
   const key = makePosKey(pos.x, pos.y)
   const item: ItemDef | undefined = scene.itemDrops.get(key)
   if (!item) return
-  const message: string = scene.addItemToInventory(item)
+  scene.addItemToInventory(item)
   scene.itemDrops.delete(key)
   scene.cameras.main.flash(120, 200, 140, 255)
-  scene.lastActionMessage = message
   scene.syncFloorLastAction?.()
 }
 


### PR DESCRIPTION
## Summary
- define mission goals and content along with supporting types
- track mission progress/rewards in player state and wire mission hooks through battles, inventory, and shops
- surface mission information in the sidebar UI
- allow select NPCs to unlock optional missions and persist which missions are available to the player

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4d1b3e1f0832eb0a2865aa7f70949