### PR TITLE
Support floor-specific spawn rules

### DIFF
--- a/src/content/armors.ts
+++ b/src/content/armors.ts
@@ -13,55 +13,70 @@ const catalog: ArmorDef[] = [
     name: '皮革護甲',
     def: 1,
     desc: '輕薄的襯層，可稍稍緩衝衝擊。',
-    attributeIds: ['light-padding', 'wind-channeling']
+    attributeIds: ['light-padding', 'wind-channeling'],
+    spawnRules: [
+      { floors: [1, 2], count: 1 }
+    ]
   },
   {
     id: 'windwalk-cloak',
     name: '風行斗篷',
     def: 2,
     desc: '以風絲織就的披覆，減緩來襲之勢。',
-    minFloor: 2,
-    attributeIds: ['wind-channeling', 'gust-barrier']
+    attributeIds: ['wind-channeling', 'gust-barrier'],
+    spawnRules: [
+      { floors: [2, 3], count: 1 }
+    ]
   },
   {
     id: 'scale-mail',
     name: '鱗甲',
     def: 3,
     desc: '厚重的甲片，以速度換取安全。',
-    minFloor: 3,
-    attributeIds: ['scale-reinforcement', 'light-padding']
+    attributeIds: ['scale-reinforcement', 'light-padding'],
+    spawnRules: [
+      { floors: [3, 4], count: 1 }
+    ]
   },
   {
     id: 'river-ward-mail',
     name: '川衛軟甲',
     def: 3,
     desc: '水紋皮革層層包覆，能順勢卸力。',
-    minFloor: 3,
-    attributeIds: ['riverflow-weave', 'wind-channeling']
+    attributeIds: ['riverflow-weave', 'wind-channeling'],
+    spawnRules: [
+      { floors: [3, 4], count: 1 }
+    ]
   },
   {
     id: 'spirit-robe',
     name: '靈紋法袍',
     def: 2,
     desc: '符咒縈繞的衣料，增強真氣。',
-    minFloor: 4,
-    attributeIds: ['spirit-warding', 'light-padding']
+    attributeIds: ['spirit-warding', 'light-padding'],
+    spawnRules: [
+      { floors: [4, 5], count: 1 }
+    ]
   },
   {
     id: 'phoenix-ward',
     name: '鳳羽護衣',
     def: 2,
     desc: '覆有赤羽的護衣，灼熱氣息守護身軀。',
-    minFloor: 4,
-    attributeIds: ['phoenix-ember', 'wind-channeling', 'light-padding']
+    attributeIds: ['phoenix-ember', 'wind-channeling', 'light-padding'],
+    spawnRules: [
+      { floors: [5, 6], count: 1 }
+    ]
   },
   {
     id: 'starfall-plate',
     name: '墜星重鎧',
     def: 3,
     desc: '隕星鋪鑄的厚鎧，連山岳衝擊也難以撼動。',
-    minFloor: 5,
-    attributeIds: ['starfall-bastion', 'scale-reinforcement']
+    attributeIds: ['starfall-bastion', 'scale-reinforcement'],
+    spawnRules: [
+      { floors: [6, 7, 8, 9, 10], count: 1 }
+    ]
   }
 ]
 

--- a/src/content/enemies.ts
+++ b/src/content/enemies.ts
@@ -1,10 +1,70 @@
 import type { EnemyDef } from '../core/Types'
 
 export const enemies: EnemyDef[] = [
-  { id: 'bandit', name: '山寨流寇', base: { hp: 40, atk: 10, def: 2 }, minFloor: 1, coinDrop: { min: 4, max: 7 } },
-  { id: 'tower-wolf', name: '塔域風狼', base: { hp: 55, atk: 12, def: 3 }, minFloor: 2, coinDrop: { min: 5, max: 9 } },
-  { id: 'ashen-adept', name: '灰燼術士', base: { hp: 48, atk: 14, def: 4 }, minFloor: 3, coinDrop: { min: 6, max: 11 } },
-  { id: 'obsidian-guard', name: '黑曜守衛', base: { hp: 70, atk: 16, def: 6 }, minFloor: 4, coinDrop: { min: 8, max: 13 } },
-  { id: 'storm-binder', name: '縛雷師', base: { hp: 62, atk: 18, def: 5 }, minFloor: 4, coinDrop: { min: 9, max: 14 } },
-  { id: 'void-mimic', name: '虛境擬影', base: { hp: 82, atk: 20, def: 7 }, minFloor: 5, coinDrop: { min: 11, max: 18 } }
+  {
+    id: 'bandit',
+    name: '山寨流寇',
+    base: { hp: 40, atk: 10, def: 2 },
+    coinDrop: { min: 4, max: 7 },
+    spawnRules: [
+      { floors: [1], count: 5 },
+      { floors: [2], count: 2 }
+    ]
+  },
+  {
+    id: 'tower-wolf',
+    name: '塔域風狼',
+    base: { hp: 55, atk: 12, def: 3 },
+    coinDrop: { min: 5, max: 9 },
+    spawnRules: [
+      { floors: [2], count: 3 },
+      { floors: [3], count: 2 }
+    ]
+  },
+  {
+    id: 'ashen-adept',
+    name: '灰燼術士',
+    base: { hp: 48, atk: 14, def: 4 },
+    coinDrop: { min: 6, max: 11 },
+    spawnRules: [
+      { floors: [3], count: 3 },
+      { floors: [4], count: 2 }
+    ]
+  },
+  {
+    id: 'obsidian-guard',
+    name: '黑曜守衛',
+    base: { hp: 70, atk: 16, def: 6 },
+    coinDrop: { min: 8, max: 13 },
+    spawnRules: [
+      { floors: [4], count: 3 },
+      { floors: [5], count: 2 }
+    ]
+  },
+  {
+    id: 'storm-binder',
+    name: '縛雷師',
+    base: { hp: 62, atk: 18, def: 5 },
+    coinDrop: { min: 9, max: 14 },
+    spawnRules: [
+      { floors: [5], count: 3 },
+      { floors: [6], count: 2 }
+    ]
+  },
+  {
+    id: 'void-mimic',
+    name: '虛境擬影',
+    base: { hp: 82, atk: 20, def: 7 },
+    coinDrop: { min: 11, max: 18 },
+    spawnRules: [
+      { floors: [6], count: 3 },
+      { floors: [7, 8, 9, 10], count: 5 }
+    ]
+  }
 ]
+
+export const enemiesById = new Map(enemies.map(enemy => [enemy.id, enemy]))
+
+export function getEnemyDef(id: string): EnemyDef | undefined {
+  return enemiesById.get(id)
+}

--- a/src/content/npcs.ts
+++ b/src/content/npcs.ts
@@ -13,22 +13,26 @@ export const npcs: NpcDef[] = [
       message: "聽了指點後，你覺得心神安穩。",
       hpDelta: 8
     },
-    offeredMissionIds: ['gather-healing-herbs']
+    offeredMissionIds: ['gather-healing-herbs'],
+    spawnRules: [
+      { floors: [1, 2], count: 1 }
+    ]
   },
   {
     id: 'scout',
     name: '遊行斥候',
-    minFloor: 2,
     lines: [
       '我已繪出前方幾條走廊。',
       '這層的商人多半聚在東側廊道。'
     ],
-    postMessage: '我能給的最好裝備就是情報。'
+    postMessage: '我能給的最好裝備就是情報。',
+    spawnRules: [
+      { floors: [2, 3], count: 1 }
+    ]
   },
   {
     id: 'armory-curator',
     name: '武庫典藏師',
-    minFloor: 3,
     lines: [
       '我替每位陣亡挑戰者記錄遺物。',
       '把這些帶上路，讓故事延續。',
@@ -38,12 +42,14 @@ export const npcs: NpcDef[] = [
       message: '典藏師默默遞給你保存良好的補給品。',
       grantItems: [{ id: 'iron-ration', quantity: 1 }]
     },
-    offeredMissionIds: ['curator-salvage']
+    offeredMissionIds: ['curator-salvage'],
+    spawnRules: [
+      { floors: [3, 4], count: 1 }
+    ]
   },
   {
     id: 'battle-scholar',
     name: '戰訣學者',
-    minFloor: 4,
     lines: [
       '你在第三口呼吸時姿勢就洩勁了。',
       '我教你一道護身真言。'
@@ -51,12 +57,14 @@ export const npcs: NpcDef[] = [
     outcome: {
       message: '你領會了更穩固的防禦。',
       grantSkills: ['stone-ward']
-    }
+    },
+    spawnRules: [
+      { floors: [4, 5], count: 1 }
+    ]
   },
   {
     id: 'vault-keeper',
     name: '密庫守者',
-    minFloor: 5,
     lines: [
       '塔裡藏的不只灰塵而已。',
       '在攀登奪走你之前，先把這些錢花掉吧。'
@@ -64,7 +72,10 @@ export const npcs: NpcDef[] = [
     outcome: {
       message: '隱藏的錢袋讓你的荷包鼓了起來。',
       coinDelta: 35
-    }
+    },
+    spawnRules: [
+      { floors: [5, 6, 7, 8, 9, 10], count: 1 }
+    ]
   }
 ]
 

--- a/src/content/shops.ts
+++ b/src/content/shops.ts
@@ -10,29 +10,36 @@ const catalog: ShopDef[] = [
       { id: 'herb-bundle', itemId: 'healing-herb', price: 55, quantity: 3 },
       { id: 'focus-tea', itemId: 'focus-tea', price: 40, quantity: 2 },
       { id: 'iron-ration', itemId: 'iron-ration', price: 45 }
+    ],
+    spawnRules: [
+      { floors: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], count: 1 }
     ]
   },
   {
     id: 'lightning-curio',
     title: '雷光古玩商',
     description: '玻璃瓶在木箱中噼啪作響，一名戴面具的商人靜靜注視著。',
-    minFloor: 2,
     offers: [
       { id: 'charge-crystal', itemId: 'charge-crystal', price: 60 },
       { id: 'ember-draught', itemId: 'ember-draught', price: 85 },
       { id: 'mist-bomb-pack', itemId: 'mist-bomb', price: 75, quantity: 2 },
       { id: 'refresher-pack', itemId: 'healing-herb', price: 90, quantity: 4 }
+    ],
+    spawnRules: [
+      { floors: [3, 4, 5, 6, 7, 8, 9, 10], count: 1 }
     ]
   },
   {
     id: 'moonlit-ritualist',
     title: '月影祭司',
     description: '身披銀紗的祭司兜售以月霜祝禱的護符與香粉。',
-    minFloor: 4,
     offers: [
       { id: 'lunar-talisman', itemId: 'lunar-talisman', price: 110 },
       { id: 'shadow-pouch', itemId: 'mist-bomb', price: 90, quantity: 3 },
       { id: 'spirit-rations', itemId: 'iron-ration', price: 95, quantity: 2 }
+    ],
+    spawnRules: [
+      { floors: [5, 6, 7, 8, 9, 10], count: 1 }
     ]
   }
 ]
@@ -40,7 +47,14 @@ const catalog: ShopDef[] = [
 export const shops: ShopDef[] = catalog
 
 export function getShopsForFloor(floor: number): ShopDef[] {
-  return catalog.filter(def => (def.minFloor ?? 1) <= floor)
+  return catalog.filter(def => {
+    if (Array.isArray(def.spawnRules) && def.spawnRules.length) {
+      return def.spawnRules.some(rule =>
+        Array.isArray(rule.floors) && rule.floors.includes(floor) && (rule.count ?? 0) > 0
+      )
+    }
+    return (def.minFloor ?? 1) <= floor
+  })
 }
 
 export const shopsById = new Map(catalog.map(shop => [shop.id, shop]))

--- a/src/content/weapons.ts
+++ b/src/content/weapons.ts
@@ -11,7 +11,10 @@ const catalog: WeaponDef[] = [
     id: 'rusty-sword',
     name: '鏽蝕長劍',
     atk: 5,
-    desc: '老舊的刀刃，總比徒手好。'
+    desc: '老舊的刀刃，總比徒手好。',
+    spawnRules: [
+      { floors: [1, 2], count: 1 }
+    ]
   },
   {
     id: 'iron-spear',
@@ -19,7 +22,9 @@ const catalog: WeaponDef[] = [
     atk: 8,
     attributeIds: ['armor-break'],
     desc: '攻守距離平衡。',
-    minFloor: 2
+    spawnRules: [
+      { floors: [2, 3], count: 1 }
+    ]
   },
   {
     id: 'jade-charm',
@@ -27,7 +32,9 @@ const catalog: WeaponDef[] = [
     atk: 10,
     attributeIds: ['vampiric-edge'],
     desc: '導引致命真氣的玄妙符器。',
-    minFloor: 3
+    spawnRules: [
+      { floors: [3, 4], count: 1 }
+    ]
   },
   {
     id: 'storm-halberd',
@@ -35,7 +42,9 @@ const catalog: WeaponDef[] = [
     atk: 12,
     attributeIds: ['storm-surge', 'fury-strike'],
     desc: '嵌有雷晶的長戟，每次擊落皆伴隨驟風。',
-    minFloor: 3
+    spawnRules: [
+      { floors: [4, 5], count: 1 }
+    ]
   },
   {
     id: 'moonshadow-daggers',
@@ -43,7 +52,9 @@ const catalog: WeaponDef[] = [
     atk: 11,
     attributeIds: ['fury-strike'],
     desc: '以月鋒鍛成的雙刃，專為敏捷刺客打造。',
-    minFloor: 3
+    spawnRules: [
+      { floors: [3, 4], count: 1 }
+    ]
   },
   {
     id: 'crag-hammer',
@@ -51,7 +62,9 @@ const catalog: WeaponDef[] = [
     atk: 14,
     attributeIds: ['fury-strike'],
     desc: '沉重的戰鎚，敲擊之勢有如碎裂山巒。',
-    minFloor: 4
+    spawnRules: [
+      { floors: [4, 5], count: 1 }
+    ]
   },
   {
     id: 'serene-flute',
@@ -59,7 +72,9 @@ const catalog: WeaponDef[] = [
     atk: 9,
     attributeIds: ['vampiric-edge'],
     desc: '一支以雲杉雕成的笛子，音色可化作靈刃。',
-    minFloor: 4
+    spawnRules: [
+      { floors: [5, 6], count: 1 }
+    ]
   },
   {
     id: 'sunforged-blade',
@@ -67,7 +82,9 @@ const catalog: WeaponDef[] = [
     atk: 16,
     attributeIds: ['armor-break', 'storm-surge'],
     desc: '以熔金赤銅淬鍛，閃耀的刀刃蘊藏灼熱。',
-    minFloor: 6
+    spawnRules: [
+      { floors: [6, 7, 8, 9, 10], count: 1 }
+    ]
   }
 ]
 

--- a/src/core/Grid.ts
+++ b/src/core/Grid.ts
@@ -3,6 +3,7 @@ import { RNG } from './RNG'
 
 type GridOptions = {
   includeDownstairs?: boolean
+  enemyCount?: number
 }
 
 export class Grid {
@@ -141,7 +142,8 @@ export class Grid {
     this.doorPos = this.place('door')
     this.stairsUpPos = this.place('stairs_up')
 
-    for (let i = 0; i < 5; i++) {
+    const enemyCount = Math.max(0, Math.floor(options?.enemyCount ?? 5))
+    for (let i = 0; i < enemyCount; i++) {
       this.enemyPos.push(this.place('enemy'))
     }
 

--- a/src/core/Types.ts
+++ b/src/core/Types.ts
@@ -16,13 +16,22 @@ export type Tile =
   | 'npc'
   | 'item'
   | 'ending'
-export interface EnemyDef {
+export interface SpawnRule {
+  floors: number[]
+  count: number
+}
+
+interface SpawnableDef {
+  minFloor?: number
+  spawnRules?: SpawnRule[]
+}
+
+export interface EnemyDef extends SpawnableDef {
   id: string
   name: string
   base: { hp: number; atk: number; def: number }
   coinDrop?: { min: number; max: number }
   mods?: string[]
-  minFloor?: number
 }
 export type WeaponAttributeId = 'armor-break' | 'fury-strike' | 'vampiric-edge' | 'storm-surge'
 export type WeaponAttributeChargeMap = Partial<Record<WeaponAttributeId, number>>
@@ -49,7 +58,13 @@ export interface WeaponAttributeDef {
   healAmount?: number
 }
 
-export interface WeaponDef { id: string; name: string; atk: number; desc?: string; minFloor?: number; attributeIds?: WeaponAttributeId[] }
+export interface WeaponDef extends SpawnableDef {
+  id: string
+  name: string
+  atk: number
+  desc?: string
+  attributeIds?: WeaponAttributeId[]
+}
 export interface ArmorAttributeDef {
   id: ArmorAttributeId
   name: string
@@ -57,12 +72,11 @@ export interface ArmorAttributeDef {
   defBonus?: number
 }
 
-export interface ArmorDef {
+export interface ArmorDef extends SpawnableDef {
   id: string
   name: string
   def: number
   desc?: string
-  minFloor?: number
   attributeIds?: ArmorAttributeId[]
 }
 export interface PlayerStats { hp: number; mp: number }
@@ -131,11 +145,10 @@ export interface ShopOffer {
   quantity?: number
 }
 
-export interface ShopDef {
+export interface ShopDef extends SpawnableDef {
   id: string
   title: string
   description: string
-  minFloor?: number
   offers: ShopOffer[]
 }
 
@@ -148,13 +161,12 @@ export interface EventDef {
   options: EventOption[]
 }
 
-export interface NpcDef {
+export interface NpcDef extends SpawnableDef {
   id: string
   name: string
   lines: string[]
   postMessage?: string
   outcome?: EventOutcome
-  minFloor?: number
   offeredMissionIds?: string[]
 }
 


### PR DESCRIPTION
## Summary
- introduce shared spawn rule metadata and update weapon, armor, enemy, NPC, and shop catalogs to declare floor-specific counts
- rework spawning utilities and game scene logic to honor explicit spawn rules, including deterministic enemy assignments and save serialization
- allow configurable enemy counts when building grids to match scripted encounters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4e66bc3cc832ea2176c98c61c337e