### PR TITLE
Enhance branch missions and elite encounters

### DIFF
--- a/src/game/player/PlayerState.ts
+++ b/src/game/player/PlayerState.ts
@@ -300,6 +300,17 @@ export class PlayerState {
     return messages
   }
 
+  resetFloorClearingMissions() {
+    this.ensureMissionEntries()
+    for (const mission of missions) {
+      if (mission.goal.type !== 'defeat-enemies') continue
+      if (typeof mission.floor !== 'number') continue
+      this.missionProgress.set(mission.id, 0)
+      this.unlockedMissionIds.delete(mission.id)
+      this.completedMissionIds.delete(mission.id)
+    }
+  }
+
   recordEnemyDefeat(_enemy?: EnemyDef | null): string[] {
     this.ensureMissionEntries()
     const messages: string[] = []

--- a/src/systems/render.ts
+++ b/src/systems/render.ts
@@ -156,8 +156,15 @@ function updateTileSprites(
     symbol.setDisplaySize(tileSize, tileSize)
     symbol.setFlipX(!!symbolConfig.flipX)
     symbol.setFlipY(!!symbolConfig.flipY)
-    if (symbolConfig.tint !== undefined) {
-      symbol.setTint(symbolConfig.tint)
+    let tint = symbolConfig.tint
+    if (tile === 'enemy') {
+      const forced = scene.enemyNodes?.get?.(posKey)
+      if (forced?.mods?.includes?.('elite')) {
+        tint = 0xff6b6b
+      }
+    }
+    if (tint !== undefined) {
+      symbol.setTint(tint)
     } else {
       symbol.clearTint()
     }
@@ -187,9 +194,13 @@ function describeTile(scene: any, tile: string, x: number, y: number): string | 
   const posKey = makePosKey(x, y)
   switch (tile) {
     case 'enemy': {
+      const forced = scene.enemyNodes?.get?.(posKey)
       const pool = enemies.filter(enemy => (enemy.minFloor ?? 1) <= scene.floor)
-      const enemy = pool.length ? pool[pool.length - 1] : enemies[0]
-      return `敵人：${enemy.name}（生命 ${enemy.base.hp}，攻擊 ${enemy.base.atk}）`
+      const fallback = pool.length ? pool[pool.length - 1] : enemies[0]
+      const enemy = forced ?? fallback
+      const isElite = forced?.mods?.includes?.('elite')
+      const prefix = isElite ? '菁英敵人' : '敵人'
+      return `${prefix}：${enemy.name}（生命 ${enemy.base.hp}，攻擊 ${enemy.base.atk}）`
     }
     case 'weapon': {
       const weapon = scene.weaponDrops?.get(posKey)


### PR DESCRIPTION
## Summary
- reset floor-clearing missions when advancing to a new floor while keeping branch progress, and route branch mission rewards back to the base floor so stairs appear in the right place
- spawn a guaranteed elite enemy in branch floors, tint elite icons, and show a reminder message when entering a branch about defeating the enemy before returning

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5648ff268832e948099561c324932