### PR TITLE
Implement multi-wave battle events with overlay-driven flow

### DIFF
--- a/src/content/battleEvents.ts
+++ b/src/content/battleEvents.ts
@@ -1,0 +1,117 @@
+import type { BattleEventDef } from '../core/Types'
+
+const catalog: BattleEventDef[] = [
+  {
+    id: 'bandit-encampment',
+    title: '山寨伏兵',
+    description:
+      '你誤闖山寨臨時據點，營火旁滿是粗糙兵刃與未分配的金袋。伏兵正待命，只要有動靜便會蜂擁而上。',
+    enemyId: 'bandit',
+    waveCount: { min: 2, max: 3 },
+    rewardOptions: [
+      {
+        id: 'bandit-encampment-heal',
+        label: '分得療傷酒，恢復 35 點生命',
+        outcome: {
+          message: '你分得伏兵囤積的藥酒，灼熱刺激修復你的傷勢。',
+          hpDelta: 35
+        }
+      },
+      {
+        id: 'bandit-encampment-coins',
+        label: '收刮金袋，獲得 30 金幣',
+        outcome: {
+          message: '你把山寨的金袋打結收入囊中。',
+          coinDelta: 30
+        }
+      },
+      {
+        id: 'bandit-encampment-items',
+        label: '搜括藥草，取得療傷藥草 x2',
+        outcome: {
+          message: '你找到幾束乾燥藥草，足以支撐後續旅程。',
+          grantItems: [{ id: 'healing-herb', quantity: 2 }]
+        }
+      }
+    ],
+    minFloor: 1
+  },
+  {
+    id: 'wolf-den-howl',
+    title: '風狼群巢',
+    description:
+      '塔域風狼盤踞於洞穴，帶頭者發出低沉嗥鳴，群狼隨著風勢輪番衝擊。若不速戰速決，很難全身而退。',
+    enemyId: 'tower-wolf',
+    waveCount: [2, 3, 4],
+    rewardOptions: [
+      {
+        id: 'wolf-den-focus',
+        label: '吸納狼息，獲得靜心茶包',
+        outcome: {
+          message: '你汲取風狼呼吸間的精氣，沖泡成一包靜心茶。',
+          grantItems: [{ id: 'focus-tea', quantity: 1 }]
+        }
+      },
+      {
+        id: 'wolf-den-mastery',
+        label: '磨練身骨，提升 20 點生命',
+        outcome: {
+          message: '與群狼周旋的經驗讓你的身軀更加堅實。',
+          hpDelta: 20
+        }
+      },
+      {
+        id: 'wolf-den-coins',
+        label: '搜集狼牙，換得 36 金幣',
+        outcome: {
+          message: '你將狼牙收束成串，估算著能換得不錯的報酬。',
+          coinDelta: 36
+        }
+      }
+    ],
+    minFloor: 2
+  },
+  {
+    id: 'obsidian-blockade',
+    title: '黑曜封鎖線',
+    description:
+      '塔衛已在狹長回廊築起封鎖線，黑曜守衛冷靜調度，輪番硬碰硬地試探你的破綻。只有連續突破，才能撼動防線。',
+    enemyId: 'obsidian-guard',
+    waveCount: { min: 3, max: 4 },
+    rewardOptions: [
+      {
+        id: 'obsidian-ward',
+        label: '撿起完好的甲片，獲得月耀符',
+        outcome: {
+          message: '守衛的甲片折射微光，你從中繪製出一道月耀符。',
+          grantItems: [{ id: 'lunar-talisman', quantity: 1 }]
+        }
+      },
+      {
+        id: 'obsidian-discipline',
+        label: '沉澱戰意，恢復 40 點生命',
+        outcome: {
+          message: '你調息黑曜殘焰，讓體內靈息再度飽滿。',
+          hpDelta: 40
+        }
+      },
+      {
+        id: 'obsidian-tribute',
+        label: '奪取軍需，獲得 48 金幣',
+        outcome: {
+          message: '你截下守衛的軍需封囊，沉甸甸地塞進行囊。',
+          coinDelta: 48
+        }
+      }
+    ],
+    minFloor: 4
+  }
+]
+
+export const battleEvents: BattleEventDef[] = catalog
+
+export const battleEventsById = new Map(catalog.map(event => [event.id, event]))
+
+export function getBattleEventDef(id: string): BattleEventDef | undefined {
+  return battleEventsById.get(id)
+}

--- a/src/core/Grid.ts
+++ b/src/core/Grid.ts
@@ -52,6 +52,7 @@ export class Grid {
       t === 'armor' ||
       t === 'event' ||
       t === 'shop' ||
+      t === 'battle_event' ||
       t === 'npc' ||
       t === 'item' ||
       t === 'ending'

--- a/src/core/Types.ts
+++ b/src/core/Types.ts
@@ -13,6 +13,7 @@ export type Tile =
   | 'event'
   | 'shop'
   | 'npc'
+  | 'battle_event'
   | 'item'
   | 'ending'
 export interface SpawnRule {
@@ -141,6 +142,20 @@ export interface EventOption {
   id: string
   label: string
   outcome: EventOutcome
+}
+
+export type BattleEventWaveSpec =
+  | number
+  | { min: number; max: number }
+  | number[]
+
+export interface BattleEventDef extends SpawnableDef {
+  id: string
+  title: string
+  description: string
+  enemyId: string
+  waveCount: BattleEventWaveSpec
+  rewardOptions: [EventOption, EventOption, EventOption]
 }
 
 export interface ShopOffer {

--- a/src/scenes/BattleEventOverlay.ts
+++ b/src/scenes/BattleEventOverlay.ts
@@ -1,0 +1,247 @@
+import Phaser from 'phaser'
+import type { BattleEventDef, EventOption, Vec2 } from '../core/Types'
+import type { GameScene } from './GameScene'
+
+export type BattleEventPromptData = {
+  mode: 'prompt'
+  event: BattleEventDef
+  pos: Vec2
+  totalWaves: number
+  remainingWaves: number
+  onFight: () => void
+  onRetreat: () => void
+}
+
+export type BattleEventRewardData = {
+  mode: 'rewards'
+  event: BattleEventDef
+  rewards: EventOption[]
+  onSelect: (option: EventOption) => void
+}
+
+export type BattleEventOverlayData = BattleEventPromptData | BattleEventRewardData
+
+export class BattleEventOverlay {
+  private readonly host: GameScene
+  isActive = false
+
+  private data: BattleEventOverlayData | null = null
+
+  private backdrop?: Phaser.GameObjects.Rectangle
+  private panel?: Phaser.GameObjects.Rectangle
+  private titleText?: Phaser.GameObjects.Text
+  private descriptionText?: Phaser.GameObjects.Text
+  private statusText?: Phaser.GameObjects.Text
+  private optionTexts: Phaser.GameObjects.Text[] = []
+  private instructionText?: Phaser.GameObjects.Text
+
+  constructor(scene: GameScene) {
+    this.host = scene
+  }
+
+  open(data: BattleEventOverlayData) {
+    this.close()
+    this.isActive = true
+    this.data = data
+    this.createUI()
+    this.host.input.keyboard?.on('keydown', this.handleKey, this)
+  }
+
+  close() {
+    if (!this.isActive) {
+      this.data = null
+      return
+    }
+
+    this.isActive = false
+    this.host.input.keyboard?.off('keydown', this.handleKey, this)
+    const elements: (Phaser.GameObjects.GameObject | undefined)[] = [
+      this.backdrop,
+      this.panel,
+      this.titleText,
+      this.descriptionText,
+      this.statusText,
+      this.instructionText,
+      ...this.optionTexts
+    ]
+    elements.forEach(el => el?.destroy())
+
+    this.backdrop = undefined
+    this.panel = undefined
+    this.titleText = undefined
+    this.descriptionText = undefined
+    this.statusText = undefined
+    this.instructionText = undefined
+    this.optionTexts = []
+    this.data = null
+  }
+
+  private createUI() {
+    if (!this.data) return
+    const { width, height } = this.host.scale
+    const panelWidth = 660
+    const panelHeight = this.data.mode === 'rewards' ? 460 : 420
+    const depthBase = 2500
+
+    this.backdrop = this.host.add
+      .rectangle(width / 2, height / 2, width, height, 0x000000, 0.6)
+      .setScrollFactor(0)
+      .setDepth(depthBase)
+      .setInteractive({ useHandCursor: false })
+
+    this.panel = this.host.add
+      .rectangle(width / 2, height / 2, panelWidth, panelHeight, 0x040c14, 0.9)
+      .setStrokeStyle(2, 0xff9c52, 0.8)
+      .setScrollFactor(0)
+      .setDepth(depthBase + 1)
+
+    const panelTop = height / 2 - panelHeight / 2
+    const panelLeft = width / 2 - panelWidth / 2
+    const contentLeft = panelLeft + 32
+
+    this.titleText = this.host.add
+      .text(width / 2, panelTop + 20, this.data.event.title, {
+        fontSize: '26px',
+        color: '#ffe6c3'
+      })
+      .setOrigin(0.5, 0)
+      .setScrollFactor(0)
+      .setDepth(depthBase + 2)
+
+    this.descriptionText = this.host.add
+      .text(contentLeft, (this.titleText?.y ?? panelTop) + 54, this.data.event.description, {
+        fontSize: '17px',
+        color: '#fff4d9',
+        wordWrap: { width: panelWidth - 64 },
+        lineSpacing: 6
+      })
+      .setScrollFactor(0)
+      .setDepth(depthBase + 2)
+
+    const statusTop = (this.descriptionText?.y ?? panelTop) + (this.descriptionText?.height ?? 0) + 26
+    this.statusText = this.host.add
+      .text(width / 2, statusTop, this.buildStatusText(), {
+        fontSize: '16px',
+        color: '#ffe0a3',
+        align: 'center',
+        wordWrap: { width: panelWidth - 80 },
+        lineSpacing: 4
+      })
+      .setOrigin(0.5, 0)
+      .setScrollFactor(0)
+      .setDepth(depthBase + 2)
+
+    this.renderOptions(panelTop, panelHeight, contentLeft)
+    this.renderInstructions(panelTop, panelHeight)
+  }
+
+  private buildStatusText(): string {
+    if (!this.data || this.data.mode !== 'prompt') {
+      return this.data?.mode === 'rewards'
+        ? '連續突破封鎖後，你得以從戰利品中選擇一份獎勵。'
+        : ''
+    }
+    const total = Math.max(1, Math.floor(this.data.totalWaves))
+    const remaining = Math.max(0, Math.floor(this.data.remainingWaves))
+    const cleared = Math.max(0, total - remaining)
+    if (remaining === total) {
+      return `波次：${total}。敵人尚未察覺，你可先手。`
+    }
+    if (remaining <= 0) {
+      return `波次：${total}。封鎖線已被擊破。`
+    }
+    return `波次：${total}。已清除 ${cleared} 波，尚餘 ${remaining} 波。`
+  }
+
+  private renderOptions(panelTop: number, _panelHeight: number, contentLeft: number) {
+    if (!this.data) return
+    this.optionTexts.forEach(text => text.destroy())
+    this.optionTexts = []
+
+    const optionBaseY = (this.statusText?.y ?? panelTop) + (this.statusText?.height ?? 0) + 24
+    if (this.data.mode === 'prompt') {
+      const options: { label: string; hotkey: string }[] = [
+        { label: '1. 迎戰', hotkey: '1' },
+        { label: '2. 撤退', hotkey: '2' }
+      ]
+      options.forEach((option, idx) => {
+        const text = this.host.add
+          .text(contentLeft, optionBaseY + idx * 34, option.label, {
+            fontSize: '18px',
+            color: '#ffffff'
+          })
+          .setScrollFactor(0)
+          .setDepth((this.panel?.depth ?? 0) + 2)
+        this.optionTexts.push(text)
+      })
+      return
+    }
+
+    const rewards = this.data.rewards
+    rewards.forEach((option, idx) => {
+      const text = this.host.add
+        .text(contentLeft, optionBaseY + idx * 64, `${idx + 1}. ${option.label}`, {
+          fontSize: '18px',
+          color: '#ffffff',
+          wordWrap: { width: (this.panel?.width ?? 600) - 72 },
+          lineSpacing: 6
+        })
+        .setScrollFactor(0)
+        .setDepth((this.panel?.depth ?? 0) + 2)
+      this.optionTexts.push(text)
+    })
+  }
+
+  private renderInstructions(panelTop: number, panelHeight: number) {
+    if (!this.data) return
+    const instruction = this.data.mode === 'prompt'
+      ? '按 1 迎戰、按 2 或 Esc 撤退。'
+      : '選擇 1-3 其一的獎勵。'
+
+    this.instructionText = this.host.add
+      .text(this.host.scale.width / 2, panelTop + panelHeight - 56, instruction, {
+        fontSize: '15px',
+        color: '#ffd8a2',
+        wordWrap: { width: (this.panel?.width ?? 600) - 80 },
+        align: 'center'
+      })
+      .setOrigin(0.5, 0)
+      .setScrollFactor(0)
+      .setDepth((this.panel?.depth ?? 0) + 2)
+  }
+
+  private handleKey(event: KeyboardEvent) {
+    if (!this.isActive || !this.data) return
+
+    if (this.data.mode === 'prompt') {
+      if (['1', 'Enter', ' ', 'Spacebar', 'Space'].includes(event.key)) {
+        event.preventDefault()
+        const onFight = this.data.onFight
+        this.close()
+        onFight()
+        return
+      }
+      if (event.key === '2' || event.key === 'Escape') {
+        event.preventDefault()
+        const onRetreat = this.data.onRetreat
+        this.close()
+        onRetreat()
+        return
+      }
+      return
+    }
+
+    if (this.data.mode === 'rewards') {
+      if (!['1', '2', '3'].includes(event.key)) return
+      const index = Number(event.key) - 1
+      const option = this.data.rewards[index]
+      if (!option) return
+      event.preventDefault()
+      const onSelect = this.data.onSelect
+      this.close()
+      onSelect(option)
+    }
+  }
+}
+
+export default BattleEventOverlay

--- a/src/systems/input.ts
+++ b/src/systems/input.ts
@@ -13,6 +13,7 @@ export function handleInput(scene: any, key: string) {
   }
 
   if (scene.battleOverlay?.isActive) return
+  if (scene.battleEventOverlay?.isActive) return
   if (scene.eventOverlay?.isActive) return
   if (scene.shopOverlay?.isActive) return
   if (scene.libraryOverlay?.isActive) return
@@ -85,6 +86,9 @@ export function handleInput(scene: any, key: string) {
       break
     case 'event':
       scene.startEvent(nextPos)
+      break
+    case 'battle_event':
+      scene.startBattleEventEncounter(nextPos)
       break
     case 'npc':
       scene.startNpc(nextPos)

--- a/src/systems/render.ts
+++ b/src/systems/render.ts
@@ -33,6 +33,7 @@ const SYMBOL_BY_TILE: Record<string, SymbolConfig> = {
   npc: { frame: 7, tint: 0x9fd4ff },
   item: { frame: 8 },
   event: { frame: 9 },
+  battle_event: { frame: 9, tint: 0xffad66 },
   ending: { frame: 9, tint: 0xff71c8 }
 }
 
@@ -226,6 +227,16 @@ function describeTile(scene: any, tile: string, x: number, y: number): string | 
     case 'event': {
       const event = scene.eventNodes?.get(posKey)
       return event ? `事件：${event.title}` : '事件：未知'
+    }
+    case 'battle_event': {
+      const battleEvent = scene.battleEventNodes?.get?.(posKey)
+      if (!battleEvent) return '強敵事件：未知'
+      const state = scene.battleEventStates?.get?.(posKey)
+      if (state) {
+        const cleared = Math.max(0, (state.totalWaves ?? 0) - (state.remainingWaves ?? 0))
+        return `強敵事件：${battleEvent.title}（進度 ${cleared}/${state.totalWaves}）`
+      }
+      return `強敵事件：${battleEvent.title}`
     }
     case 'npc': {
       const npc = scene.npcNodes?.get(posKey)


### PR DESCRIPTION
## Summary
- add data definitions for battle events, including wave configurations and reward options
- create a dedicated battle event overlay and integrate it with the game scene to manage encounter flow, state, and rewards
- extend input, rendering, tiles, and serialization to recognize battle-event tiles and persist encounter progress

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6b1aa8194832e97719cddca4ae32e